### PR TITLE
Add twilio.com change password URL

### DIFF
--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -21,6 +21,7 @@
     "nytimes.com": "https://myaccount.nytimes.com/seg/profile",
     "patreon.com": "https://www.patreon.com/settings/profile",
     "tripit.com": "https://tripit.com/account/edit/section/change_password",
+    "twilio.com": "https://www.twilio.com/console/user/settings",
     "twitch.tv": "https://www.twitch.tv/settings/security",
     "xfinity.com": "https://customer.xfinity.com/users/me/update-password",
     "yahoo.com": "https://login.yahoo.com/account/change-password",


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)
- [x] The top-level JSON objects are sorted alphabetically 
- [x] There is no Well-Known URL for Changing Passwords (`https://example.com/.well-known/change-password`)
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update.
